### PR TITLE
Nav menu

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,24 @@
+const plugins = [
+  [
+    'babel-plugin-import',
+    {
+      'libraryName': '@material-ui/core',
+      // Use "'libraryDirectory': ''," if your bundler does not support ES modules
+      'libraryDirectory': 'esm',
+      'camel2DashComponentName': false
+    },
+    'core'
+  ],
+  [
+    'babel-plugin-import',
+    {
+      'libraryName': '@material-ui/icons',
+      // Use "'libraryDirectory': ''," if your bundler does not support ES modules
+      'libraryDirectory': 'esm',
+      'camel2DashComponentName': false
+    },
+    'icons'
+  ]
+];
+
+module.exports = {plugins};

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "node": true
   },
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "import", "prettier", "sort-imports-es6-autofix"],
+  "plugins": ["@typescript-eslint", "import", "prettier", "sort-imports-es6-autofix", "unused-imports"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
@@ -53,6 +53,12 @@
       {
         "memberSyntaxSortOrder": ["all", "single", "multiple", "none"]
       }
+    ],
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports-ts": "error",
+    "unused-imports/no-unused-vars-ts": [
+      "warn",
+      { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
     ]
   },
   "settings": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,7 @@
             "position": "before"
           },
           {
-            "pattern": "types",
+            "pattern": "@app/types",
             "group": "internal",
             "position": "before"
           },
@@ -54,5 +54,15 @@
         "memberSyntaxSortOrder": ["all", "single", "multiple", "none"]
       }
     ]
+  },
+  "settings": {
+    "import/resolver": {
+      "eslint-import-resolver-custom-alias": {
+        "alias": {
+          "@app": "./src"
+        },
+        "extensions": [".ts", ".tsx"]
+      }
+    }
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [10.x]
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Run a one-line script
-      run: echo Hello, world!
-    - name: Run a multi-line script
-      run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: yarn --frozen-lockfile
+    - name: Build
+      run: yarn build
+    - name: Lint
+      run: yarn lint

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,9 @@
+const { alias, configPaths } = require('react-app-rewire-alias');
+const { override, useBabelRc } = require('customize-cra');
+
+module.exports = override(
+  useBabelRc(),
+  alias({
+    ...configPaths('tsconfig.paths.json')
+  })
+)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
-    "lint": "eslint . --ext .ts,.tsx --fix"
+    "lint": "eslint . --ext .ts,.tsx"
   },
   "browserslist": {
     "production": [
@@ -61,6 +61,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
+    "eslint-plugin-unused-imports": "^0.1.3",
     "prettier": "^1.19.1",
     "prettier-eslint": "^9.0.1",
     "react-app-rewire-alias": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "yup": "^0.27.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
+    "eject": "react-app-rewired eject",
     "lint": "eslint . --ext .ts,.tsx --fix"
   },
   "browserslist": {
@@ -52,13 +52,18 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
+    "babel-plugin-import": "^1.13.0",
+    "customize-cra": "^1.0.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-config-react-app": "^5.1.0",
+    "eslint-import-resolver-custom-alias": "^1.2.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "prettier": "^1.19.1",
-    "prettier-eslint": "^9.0.1"
+    "prettier-eslint": "^9.0.1",
+    "react-app-rewire-alias": "^0.1.4",
+    "react-app-rewired": "^2.1.6"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { BrowserRouter } from 'react-router-dom';
 import { CssBaseline } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
@@ -19,12 +20,12 @@ const App: React.FC = () => {
   useStyles();
 
   return (
-    <React.Fragment>
+    <BrowserRouter>
       <CssBaseline />
       <Resident51Contexts>
         <Home />
       </Resident51Contexts>
-    </React.Fragment>
+    </BrowserRouter>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 
 import { CssBaseline } from '@material-ui/core';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 
-import Navigation from './components/navigation/Header';
+import Home from './components/Home';
 import Resident51Contexts from './contexts';
-import Routes from './components/Routes';
 
 const useStyles = makeStyles({
   '@global': {
@@ -23,13 +21,9 @@ const App: React.FC = () => {
   return (
     <React.Fragment>
       <CssBaseline />
-      <Router>
-        <Resident51Contexts>
-          <Navigation>
-            <Routes />
-          </Navigation>
-        </Resident51Contexts>
-      </Router>
+      <Resident51Contexts>
+        <Home />
+      </Resident51Contexts>
     </React.Fragment>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { CssBaseline } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-import Home from './components/Home';
-import Resident51Contexts from './contexts';
+import Home from '@app/components/Home';
+import Resident51Contexts from '@app/contexts';
 
 const useStyles = makeStyles({
   '@global': {

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { BrowserRouter } from 'react-router-dom';
-
 import { useEvents } from '@app/contexts/Events';
 import { useUser } from '@app/contexts/User';
 
@@ -12,12 +10,12 @@ const Home: React.FC = () => {
   const { events } = useEvents();
 
   return (
-    <BrowserRouter>
+    <>
       <Header />
       <div>
         hey {user.displayName || 'pal'}, there's {events ? events.length : '(loading)'} events.
       </div>
-    </BrowserRouter>
+    </>
   );
 };
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { BrowserRouter } from 'react-router-dom';
 
-import { useEvents } from '../contexts/Events';
-import { useUser } from '../contexts/User';
+import { useEvents } from '@app/contexts/Events';
+import { useUser } from '@app/contexts/User';
 
 import Header from './navigation/Header';
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { BrowserRouter } from 'react-router-dom';
+
 import { useEvents } from '../contexts/Events';
 import { useUser } from '../contexts/User';
 
@@ -8,13 +10,14 @@ import Header from './navigation/Header';
 const Home: React.FC = () => {
   const { user } = useUser();
   const { events } = useEvents();
+
   return (
-    <React.Fragment>
+    <BrowserRouter>
       <Header />
       <div>
         hey {user.displayName || 'pal'}, there's {events ? events.length : '(loading)'} events.
       </div>
-    </React.Fragment>
+    </BrowserRouter>
   );
 };
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -4,9 +4,9 @@ import { useHistory } from 'react-router-dom';
 
 import 'firebaseui/dist/firebaseui.css';
 
-import useDocumentTitle from '../hooks/useDocumentTitle';
-import { FacebookAuthProvider, GoogleAuthProvider, logError, ui } from '../firebase/firebase';
-import { UserContext } from '../contexts/User';
+import useDocumentTitle from '@app/hooks/useDocumentTitle';
+import { FacebookAuthProvider, GoogleAuthProvider, logError, ui } from '@app/firebase/firebase';
+import { UserContext } from '@app/contexts/User';
 
 const Login: React.FC = () => {
   useDocumentTitle('Log In');

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import useDocumentTitle from '../hooks/useDocumentTitle';
+import useDocumentTitle from '@app/hooks/useDocumentTitle';
 
 const NotFound: React.FC = () => {
   useDocumentTitle('Not Found');

--- a/src/components/navigation/AuthActionButton.tsx
+++ b/src/components/navigation/AuthActionButton.tsx
@@ -5,10 +5,12 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import clsx from 'clsx';
 
+import { ModalCtx } from '@app/types';
+
+import { useModal } from '@app/contexts/ui/ModalProvider';
+import { useUser } from '@app/contexts/User';
+
 import Login from '../auth/Login';
-import { ModalCtx } from '../../types';
-import { useModal } from '../../contexts/ui/ModalProvider';
-import { useUser } from '../../contexts/User';
 
 import useStyles from './AuthActionButton.jss';
 

--- a/src/components/navigation/Header.jss.ts
+++ b/src/components/navigation/Header.jss.ts
@@ -1,31 +1,12 @@
 import { Theme, makeStyles } from '@material-ui/core/styles';
 
-const drawerWidth = 300;
 export default makeStyles((theme: Theme) => ({
   overlayAppBar: {
-    zIndex: theme.zIndex.modal + 1,
+    boxShadow: theme.shadows[2],
   },
   toolbarOffset: theme.mixins.toolbar,
   menuButton: {
     marginRight: theme.spacing(2),
     color: theme.palette.primary.contrastText,
-  },
-  drawer: {
-    width: drawerWidth,
-  },
-  root: {
-    display: 'flex',
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-  },
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: theme.spacing(0, 1),
-    // necessary for content to be below app bar
-    ...theme.mixins.toolbar,
   },
 }));

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -11,14 +11,14 @@ import SlideMenu from './SlideMenu';
 
 import useStyles from './Header.jss';
 
-const Header: React.FC = ({ children }) => {
+const Header: React.FC = () => {
   const [anchorEl, setAnchorEl] = React.useState<(EventTarget & HTMLButtonElement) | null>(null);
-  // const modalContext: ModalCtx = useModal();
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const history = useHistory();
   const classes = useStyles();
 
-  const handleMenuButtonClick = useCallback(() => {
+  const handleMenuButtonClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
     setDrawerOpen(prevState => !prevState);
   }, []);
 
@@ -28,6 +28,10 @@ const Header: React.FC = ({ children }) => {
   );
   const handleProfileMenuClose = useCallback((): void => {
     setAnchorEl(null);
+  }, []);
+
+  const handleDrawerOpen = useCallback(() => {
+    setDrawerOpen(true);
   }, []);
 
   const handleDrawerClose = useCallback(() => {
@@ -40,8 +44,8 @@ const Header: React.FC = ({ children }) => {
   const isMenuOpen = Boolean(anchorEl);
 
   return (
-    <div className={classes.root}>
-      <AppBar position="fixed" className={classes.overlayAppBar}>
+    <>
+      <AppBar position="fixed" className={classes.overlayAppBar} onClick={handleDrawerClose}>
         <Toolbar>
           <IconButton edge="start" className={classes.menuButton} onClick={handleMenuButtonClick}>
             {drawerOpen ? <MenuOpenIcon /> : <MenuIcon />}
@@ -65,15 +69,13 @@ const Header: React.FC = ({ children }) => {
         </Menu>
       </AppBar>
       <div className={classes.toolbarOffset} />
-      <SlideMenu open={drawerOpen} onRequestClose={handleDrawerClose} />
-      <main className={classes.content}>
-        <div className={classes.toolbar} />
-        {children}
-      </main>
-    </div>
+      <SlideMenu
+        open={drawerOpen}
+        onRequestOpen={handleDrawerOpen}
+        onRequestClose={handleDrawerClose}
+      />
+    </>
   );
 };
 
 export default Header;
-
-// #TODO merge the two appbars that now exist in the app after fixing all merge conflicts.

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   BusinessCenter as BusinessCenterIcon,
   Feedback as FeedbackIcon,
-  Gavel as GavelIcon,
   GitHub as GithubIcon,
 } from '@material-ui/icons';
 

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -7,7 +7,7 @@ import {
   GitHub as GithubIcon,
 } from '@material-ui/icons';
 
-import { NavItemParents, NavigationItem, UtilityItem } from '../../types';
+import { NavItemParents, NavigationItem, UtilityItem } from '@app/types';
 
 const navigationItems: NavigationItem[] = [
   {

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -28,12 +28,6 @@ const navigationItems: NavigationItem[] = [
       },
     ],
   },
-  {
-    id: 'jboards',
-    text: 'Jboards',
-    icon: <GavelIcon />,
-    path: '/path',
-  },
 ];
 
 const utilityItems: UtilityItem[] = [

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-import BusinessCenterIcon from '@material-ui/icons/BusinessCenter';
-import FeedbackIcon from '@material-ui/icons/Feedback';
-import GithubIcon from '@material-ui/icons/GitHub';
+import {
+  BusinessCenter as BusinessCenterIcon,
+  Feedback as FeedbackIcon,
+  Gavel as GavelIcon,
+  GitHub as GithubIcon,
+} from '@material-ui/icons';
 
 import { NavItemParents, NavigationItem, UtilityItem } from '../../types';
 
@@ -24,6 +27,12 @@ const navigationItems: NavigationItem[] = [
         ],
       },
     ],
+  },
+  {
+    id: 'jboards',
+    text: 'Jboards',
+    icon: <GavelIcon />,
+    path: '/path',
   },
 ];
 

--- a/src/components/navigation/SlideMenu.jss.ts
+++ b/src/components/navigation/SlideMenu.jss.ts
@@ -2,16 +2,23 @@ import { Theme, makeStyles } from '@material-ui/core/styles';
 
 const drawerWidth = 300;
 export default makeStyles((theme: Theme) => ({
-  overlayAppBar: {
-    zIndex: theme.zIndex.modal + 1,
-  },
   toolbarOffset: theme.mixins.toolbar,
-  rainbowOffset: {
-    height: '5px',
-    width: '100%',
-  },
   drawer: {
+    overflowX: 'hidden',
+
+    [theme.breakpoints.up('sm')]: {
+      transition:
+        theme.transitions.create('width', {
+          easing: theme.transitions.easing.sharp,
+          duration: theme.transitions.duration.short,
+        }) + ' !important',
+    },
+  },
+  drawerOpen: {
     width: drawerWidth,
+  },
+  drawerClose: {
+    width: theme.spacing(7),
   },
   nestedListItem: {
     paddingLeft: theme.spacing(3),
@@ -21,14 +28,18 @@ export default makeStyles((theme: Theme) => ({
     display: 'flex',
     flexFlow: 'column',
     overflow: 'hidden',
+    width: drawerWidth,
   },
   navListContainer: {
     flexGrow: 1,
     flexShrink: 1,
     overflow: 'auto',
   },
+  navListClose: {
+    overflowX: 'hidden',
+  },
   utilityListContainer: {
     flexShrink: 0,
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacing(1),
   },
 }));

--- a/src/components/navigation/SlideMenu.tsx
+++ b/src/components/navigation/SlideMenu.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { Divider, Drawer, List, useMediaQuery } from '@material-ui/core';
 import { useTheme } from '@material-ui/core/styles';
 
-import { NavigationItem, UtilityItem } from '../../types';
+import { NavigationItem, UtilityItem } from '@app/types';
 
 import SlideMenuProvider from './SlideMenuContext';
 import { NavListItem, UtilityListItem } from './SlideMenuItems';

--- a/src/components/navigation/SlideMenu.tsx
+++ b/src/components/navigation/SlideMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import clsx from 'clsx';
 import { Divider, Drawer, List, useMediaQuery } from '@material-ui/core';
@@ -35,13 +35,13 @@ const SlideMenu: React.FC<SlideMenuProps> = props => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
   const classes = useStyles();
-  const drawerClass: string = clsx(classes.drawer, {
+  const drawerClass = clsx(classes.drawer, {
     [classes.drawerOpen]: !isMobile && open,
     [classes.drawerClose]: !isMobile && !open,
   });
-  const navListClass: string = clsx(classes.navListContainer, { [classes.navListClose]: !open });
+  const navListClass = clsx(classes.navListContainer, { [classes.navListClose]: !open });
 
-  const updateRootStyles = useCallback(
+  const updateDrawerZIndex = useCallback(
     (ref: HTMLElement | null) => {
       if (ref) {
         ref.style.zIndex = `${theme.zIndex.appBar - 1}`;
@@ -78,7 +78,7 @@ const SlideMenu: React.FC<SlideMenuProps> = props => {
     <SlideMenuProvider>
       <Drawer
         open={isMobile ? open : true}
-        ref={updateRootStyles}
+        ref={updateDrawerZIndex}
         onClose={onRequestClose}
         className={drawerClass}
         classes={{ paper: drawerClass }}

--- a/src/components/navigation/SlideMenuContext.tsx
+++ b/src/components/navigation/SlideMenuContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 
 import { useHistory } from 'react-router-dom';
 
-import { SlideMenuCtx } from '../../types';
+import { SlideMenuCtx } from '@app/types';
 
 import { navigationItemParentMap } from './NavigationItems';
 

--- a/src/components/navigation/SlideMenuContext.tsx
+++ b/src/components/navigation/SlideMenuContext.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { useHistory } from 'react-router-dom';
+
+import { SlideMenuCtx } from '../../types';
+
+import { navigationItemParentMap } from './NavigationItems';
+
+interface ActiveNavItem {
+  id: string;
+  path: string;
+  parents: string[];
+}
+
+const SlideMenuContext = createContext<SlideMenuCtx>(null);
+const useSlideMenuState = (): SlideMenuCtx => useContext(SlideMenuContext);
+
+const SlideMenuProvider: React.FC = props => {
+  const [expandedNavItems, setExpandedNavItems] = useState<string[]>([]);
+  const [activeNavItem, setActiveNavItem] = useState<ActiveNavItem | undefined>();
+  const history = useHistory();
+
+  const addExpandedNavItem = useCallback((id: string): void => {
+    setExpandedNavItems(prevExpandedNavItems => {
+      if (prevExpandedNavItems.includes(id)) {
+        return prevExpandedNavItems;
+      }
+      return [...prevExpandedNavItems, id];
+    });
+  }, []);
+
+  const removeExpandedNavItem = useCallback((id: string): void => {
+    setExpandedNavItems(prevExpandedNavItems => {
+      if (!prevExpandedNavItems.includes(id)) {
+        return prevExpandedNavItems;
+      }
+      return prevExpandedNavItems.filter(item => item !== id);
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = history.listen(location => {
+      const activeItemKey = Object.keys(navigationItemParentMap).find(
+        key => navigationItemParentMap[key].path === location.pathname,
+      );
+      const activeItem = activeItemKey
+        ? {
+            id: activeItemKey,
+            ...navigationItemParentMap[activeItemKey],
+          }
+        : undefined;
+      setExpandedNavItems(activeItem?.parents ? [...activeItem.parents] : []);
+      setActiveNavItem(activeItem);
+    });
+
+    return unlisten;
+  }, [addExpandedNavItem, history]);
+
+  const contextValue = useMemo(
+    () => ({
+      expandedNavItems,
+      activeNavItem,
+      expandNavItem: addExpandedNavItem,
+      collapseNavItem: removeExpandedNavItem,
+    }),
+    [activeNavItem, addExpandedNavItem, expandedNavItems, removeExpandedNavItem],
+  );
+
+  return (
+    <SlideMenuContext.Provider value={contextValue}>{props.children}</SlideMenuContext.Provider>
+  );
+};
+
+export { SlideMenuContext, useSlideMenuState };
+export default SlideMenuProvider;

--- a/src/components/navigation/SlideMenuItems.tsx
+++ b/src/components/navigation/SlideMenuItems.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { Collapse, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';

--- a/src/components/navigation/SlideMenuItems.tsx
+++ b/src/components/navigation/SlideMenuItems.tsx
@@ -1,86 +1,122 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { Collapse, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { useHistory } from 'react-router-dom';
 
 import { NavigationItem, UtilityItem } from '../../types';
+import { useModal } from '../../contexts/ui/ModalProvider';
 
-import { navigationItemParentMap } from './NavigationItems';
+import { useSlideMenuState } from './SlideMenuContext';
 
 import useStyles from './SlideMenu.jss';
-
-const menuState = {
-  expandedNavItems: new Set<string>(),
-};
 
 /**
  * List item for the navigation list in the slide menu
  */
 interface NavListItemProps extends NavigationItem {
-  menuClosingAction: () => void;
+  onRequestOpen: () => void;
+  onRequestClose: () => void;
+  isDrawerOpen: boolean;
 }
+
 const NavListItem: React.FC<NavListItemProps> = props => {
-  const [open, setOpen] = useState<boolean>(menuState.expandedNavItems.has(props.id));
+  const {
+    id,
+    subItemList,
+    path,
+    onRequestClose,
+    onRequestOpen,
+    isDrawerOpen,
+    isVisible,
+    icon,
+    text,
+  } = props;
   const history = useHistory();
+  const menuState = useSlideMenuState();
   const classes = useStyles();
-  const hasSubList = !!props.subItemList?.length;
-  const isSelected: boolean = history.location.pathname === props.path;
+  const hasSubList = !!subItemList?.length;
+  const sublistOpen = !!menuState?.expandedNavItems.includes(id);
+  const isSelected: boolean = ((): boolean => {
+    if (menuState?.activeNavItem && menuState?.activeNavItem?.path === path) return true;
+    if (isDrawerOpen) return false;
+    if (menuState?.activeNavItem?.parents.includes(id)) return true;
+    return false;
+  })();
 
-  // @ATTENTION I'd like to use rrd's useHistory hook - will this cause any issues?
-  useEffect(() => {
-    history.listen(location => {
-      const activeItem = Object.values(navigationItemParentMap).find(
-        item => item.path === location.pathname,
-      );
-      if (activeItem) {
-        activeItem.parents.forEach(parent => menuState.expandedNavItems.add(parent));
-      }
-    });
-  }, [history]);
-
-  const handleClick = (): void => {
-    if (hasSubList) {
-      if (open) {
-        menuState.expandedNavItems.delete(props.id);
-        setOpen(false);
+  const handleClick = useCallback((): void => {
+    if (!isDrawerOpen) {
+      onRequestOpen();
+    } else if (hasSubList) {
+      if (sublistOpen) {
+        menuState?.collapseNavItem(id);
       } else {
-        menuState.expandedNavItems.add(props.id);
-        setOpen(true);
+        menuState?.expandNavItem(id);
       }
-    } else if (props.path) {
-      history.push(props.path);
-      props.menuClosingAction();
+    } else if (path) {
+      history.push(path);
+      onRequestClose();
     }
-  };
+  }, [
+    hasSubList,
+    path,
+    isDrawerOpen,
+    sublistOpen,
+    onRequestOpen,
+    menuState,
+    id,
+    history,
+    onRequestClose,
+  ]);
 
-  const expandButton = open ? <ExpandLess /> : <ExpandMore />;
+  const expandButton = isDrawerOpen && sublistOpen ? <ExpandLess /> : <ExpandMore />;
 
   const subList: React.ReactNode = useMemo(
     () =>
       hasSubList ? (
-        <Collapse in={open} timeout="auto">
+        <Collapse in={isDrawerOpen ? sublistOpen : false} timeout="auto">
           <List className={classes.nestedListItem} disablePadding>
-            {props.subItemList
+            {subItemList
               ?.map((item: NavigationItem) => (
-                <NavListItem key={item.id} {...item} menuClosingAction={props.menuClosingAction} />
+                <NavListItem
+                  key={item.id}
+                  {...item}
+                  onRequestOpen={onRequestOpen}
+                  onRequestClose={onRequestClose}
+                  isDrawerOpen={isDrawerOpen}
+                />
               ))
               .filter(Boolean)}
           </List>
         </Collapse>
       ) : null,
-    [classes.nestedListItem, hasSubList, open, props.menuClosingAction, props.subItemList],
+    [
+      hasSubList,
+      isDrawerOpen,
+      sublistOpen,
+      classes.nestedListItem,
+      subItemList,
+      onRequestOpen,
+      onRequestClose,
+    ],
   );
 
-  if (props.isVisible && !props.isVisible()) {
+  useEffect(() => {
+    if (isDrawerOpen && menuState?.activeNavItem?.parents.includes(id)) {
+      menuState.expandNavItem(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDrawerOpen]);
+
+  if (isVisible && !isVisible()) {
     return null;
   }
 
   return (
     <>
       <ListItem onClick={handleClick} selected={isSelected} button>
-        {props.icon ? <ListItemIcon>{props.icon}</ListItemIcon> : null}
-        <ListItemText primary={props.text} />
+        {icon ? <ListItemIcon>{icon}</ListItemIcon> : null}
+        <ListItemText primary={isDrawerOpen ? text : `${text.substring(0, 4)}...`} />
         {hasSubList ? expandButton : null}
       </ListItem>
       {subList}
@@ -95,10 +131,16 @@ interface UtilityListItemProps extends UtilityItem {
   menuClosingAction: () => void;
 }
 const UtilityListItem: React.FC<UtilityListItemProps> = props => {
+  const modalContext = useModal();
+
   const handleClick = (): void => {
     if (props.clickBehavior === 'disclose') {
-      // open modal
-      props.menuClosingAction();
+      if (props.disclosureComponent) {
+        props.menuClosingAction();
+        modalContext?.disclose({
+          content: props.disclosureComponent,
+        });
+      }
     } else if (props.clickBehavior === 'link') {
       if (props.url) {
         props.menuClosingAction();

--- a/src/components/navigation/SlideMenuItems.tsx
+++ b/src/components/navigation/SlideMenuItems.tsx
@@ -4,8 +4,9 @@ import { Collapse, List, ListItem, ListItemIcon, ListItemText } from '@material-
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { useHistory } from 'react-router-dom';
 
-import { NavigationItem, UtilityItem } from '../../types';
-import { useModal } from '../../contexts/ui/ModalProvider';
+import { NavigationItem, UtilityItem } from '@app/types';
+
+import { useModal } from '@app/contexts/ui/ModalProvider';
 
 import { useSlideMenuState } from './SlideMenuContext';
 

--- a/src/components/navigation/SlideMenuItems.tsx
+++ b/src/components/navigation/SlideMenuItems.tsx
@@ -39,13 +39,16 @@ const NavListItem: React.FC<NavListItemProps> = props => {
   const hasSubList = !!subItemList?.length;
   const sublistOpen = !!menuState?.expandedNavItems.includes(id);
   const isSelected: boolean = ((): boolean => {
+    // If this is the active nav item return true
     if (menuState?.activeNavItem && menuState?.activeNavItem?.path === path) return true;
+    // If the drawer is open and this isn't the active nav item return false
     if (isDrawerOpen) return false;
+    // If the drawer is closed and this is the parent of the active nav item return true
     if (menuState?.activeNavItem?.parents.includes(id)) return true;
     return false;
   })();
 
-  const handleClick = useCallback((): void => {
+  const handleClick = (): void => {
     if (!isDrawerOpen) {
       onRequestOpen();
     } else if (hasSubList) {
@@ -58,17 +61,7 @@ const NavListItem: React.FC<NavListItemProps> = props => {
       history.push(path);
       onRequestClose();
     }
-  }, [
-    hasSubList,
-    path,
-    isDrawerOpen,
-    sublistOpen,
-    onRequestOpen,
-    menuState,
-    id,
-    history,
-    onRequestClose,
-  ]);
+  };
 
   const expandButton = isDrawerOpen && sublistOpen ? <ExpandLess /> : <ExpandMore />;
 

--- a/src/contexts/Events.tsx
+++ b/src/contexts/Events.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useEffect, useReducer } from 'react';
 
-import EventsReducer from '../reducers/Events.Reducer';
 import {
   EventForm as EventFormType,
   EventToCFS,
@@ -8,8 +7,10 @@ import {
   EventTypeFormats,
   Events,
   Hall,
-} from '../types/';
-import { currentEvents } from '../firebase/firebase';
+} from '@app/types/';
+
+import EventsReducer from '@app/reducers/Events.Reducer';
+import { currentEvents } from '@app/firebase/firebase';
 
 import {
   concatEvents,

--- a/src/contexts/EventsProps.ts
+++ b/src/contexts/EventsProps.ts
@@ -11,8 +11,9 @@ import {
   EventTypeFormats,
   Events,
   Hall,
-} from '../types/';
-import { EventAction } from '../reducers/Events.Reducer';
+} from '@app/types/';
+
+import { EventAction } from '@app/reducers/Events.Reducer';
 
 export const eventTypes: EventTypeFormats = {
   social: { formal: 'Social Event', color: 'green' },

--- a/src/contexts/User.tsx
+++ b/src/contexts/User.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useMemo, useReducer } from
 import UserReducer, { UserAction } from '../reducers/User.Reducer';
 import useFirebaseAuth from '../hooks/useFirebaseAuth';
 import useUserCollection from '../hooks/useUserCollection';
-import { FetchedUser, User } from '../types/';
+import { FetchedUser, User } from '../types';
 import { logUser, usersCollection } from '../firebase/firebase';
 
 import { loggedOutUser } from './UserProps';

--- a/src/contexts/User.tsx
+++ b/src/contexts/User.tsx
@@ -1,10 +1,11 @@
 import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 
-import UserReducer, { UserAction } from '../reducers/User.Reducer';
-import useFirebaseAuth from '../hooks/useFirebaseAuth';
-import useUserCollection from '../hooks/useUserCollection';
-import { FetchedUser, User } from '../types';
-import { logUser, usersCollection } from '../firebase/firebase';
+import { FetchedUser, User } from '@app/types';
+
+import UserReducer, { UserAction } from '@app/reducers/User.Reducer';
+import useFirebaseAuth from '@app/hooks/useFirebaseAuth';
+import useUserCollection from '@app/hooks/useUserCollection';
+import { logUser, usersCollection } from '@app/firebase/firebase';
 
 import { loggedOutUser } from './UserProps';
 

--- a/src/contexts/UserProps.ts
+++ b/src/contexts/UserProps.ts
@@ -1,4 +1,4 @@
-import { LoggedOutUser, UnverifiedUser, User, UserDocument } from '../types';
+import { LoggedOutUser, UnverifiedUser, User, UserDocument } from '@app/types';
 
 export const loggedOutUser: LoggedOutUser = {
   uid: null,

--- a/src/contexts/ui/AlertDialogProvider.jss.ts
+++ b/src/contexts/ui/AlertDialogProvider.jss.ts
@@ -1,6 +1,6 @@
-import { Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles((theme: Theme) => ({
+export default makeStyles(() => ({
   alertDialogContainer: {
     minWidth: `280px`,
   },

--- a/src/contexts/ui/AlertDialogProvider.tsx
+++ b/src/contexts/ui/AlertDialogProvider.tsx
@@ -13,7 +13,7 @@ import {
 import { Close as CloseIcon } from '@material-ui/icons';
 import { useSnackbar } from 'notistack';
 
-import { AlertDialogControls, AlertDialogCtx, AlertDialogOptions } from '../../types';
+import { AlertDialogControls, AlertDialogCtx, AlertDialogOptions } from '@app/types';
 
 import useStyles from './AlertDialogProvider.jss';
 

--- a/src/contexts/ui/AlertDialogProvider.tsx
+++ b/src/contexts/ui/AlertDialogProvider.tsx
@@ -50,12 +50,6 @@ const AlertDialogProvider: React.FC = props => {
     setOptions(null);
   }, []);
 
-  const updateRootStyle = useCallback((ref?: HTMLElement) => {
-    if (ref) {
-      ref.style.zIndex = '1350';
-    }
-  }, []);
-
   const handleButtonClick = useCallback(
     (type: 'primary' | 'secondary') => {
       const callback =
@@ -144,7 +138,6 @@ const AlertDialogProvider: React.FC = props => {
         onExited={handleExited}
         aria-labelledby={`${alertId}-title`}
         aria-describedby={`${alertId}-content`}
-        ref={updateRootStyle}
       >
         <div className={classes.alertDialogTitle}>
           <DialogTitle id={`${alertId}-title`}>{options?.title ? options.title : ''}</DialogTitle>

--- a/src/contexts/ui/LoadingOverlayProvider.jss.ts
+++ b/src/contexts/ui/LoadingOverlayProvider.jss.ts
@@ -1,6 +1,6 @@
-import { Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles((theme: Theme) => ({
+export default makeStyles(() => ({
   appLoadingOverlay: {
     zIndex: 1400,
   },

--- a/src/contexts/ui/LoadingOverlayProvider.tsx
+++ b/src/contexts/ui/LoadingOverlayProvider.tsx
@@ -17,7 +17,7 @@ import {
   LoadingOverlayControls,
   LoadingOverlayCtx,
   LoadingOverlayInitializer,
-} from '../../types';
+} from '@app/types';
 
 import useStyles from './LoadingOverlayProvider.jss';
 

--- a/src/contexts/ui/LoadingOverlayProvider.tsx
+++ b/src/contexts/ui/LoadingOverlayProvider.tsx
@@ -30,7 +30,7 @@ const LoadingOverlayProvider: React.FC = props => {
 
   const setLoaderStatus = useCallback((key: string, value: boolean) => {
     setRegisteredLoaders((loaders: LoadingOverlayConfig[]) => {
-      const dupLoaders = loaders;
+      const dupLoaders = [...loaders];
       const requestedLoader = dupLoaders.find((loader: LoadingOverlayConfig) => {
         return loader.key === key;
       });
@@ -43,7 +43,7 @@ const LoadingOverlayProvider: React.FC = props => {
 
   const deregisterLoader = useCallback((key: string) => {
     setRegisteredLoaders((loaders: LoadingOverlayConfig[]) => {
-      const dupLoaders = loaders;
+      const dupLoaders = [...loaders];
       const requestedLoaderIndex: number = dupLoaders.findIndex((loader: LoadingOverlayConfig) => {
         return loader.key === key;
       });

--- a/src/contexts/ui/ModalProvider.tsx
+++ b/src/contexts/ui/ModalProvider.tsx
@@ -11,7 +11,7 @@ import React, {
 
 import clsx from 'clsx';
 import uniqid from 'uniqid';
-import { Backdrop, CircularProgress, Grow, LinearProgress, Modal, Paper } from '@material-ui/core';
+import { Grow, LinearProgress, Modal, Paper } from '@material-ui/core';
 
 import { ModalCtx, ModalOptions } from '../../types';
 
@@ -31,12 +31,6 @@ const ModalProvider: React.FC = props => {
   const dismissCallback = useRef<(() => void) | null>(null);
   const contentKey = useRef<string>();
   const classes = useStyles();
-
-  const updateRootStyle = useCallback((ref?: HTMLElement) => {
-    if (ref) {
-      ref.style.zIndex = '1325';
-    }
-  }, []);
 
   const disclose = useCallback((modalOptions: ModalOptions): void => {
     contentKey.current = uniqid('modal-');
@@ -66,6 +60,7 @@ const ModalProvider: React.FC = props => {
     setModalProps({});
     setTimeout(() => {
       setOpen(false);
+      setLoading(false);
       setContent(null);
     }, 400);
   }, []);
@@ -86,7 +81,6 @@ const ModalProvider: React.FC = props => {
   return (
     <ModalContext.Provider value={{ disclose, dismiss: dismissWithoutNotification }}>
       <Modal
-        ref={updateRootStyle}
         className={classes.modalRootContainer}
         open={open}
         onClose={handleClose}

--- a/src/contexts/ui/ModalProvider.tsx
+++ b/src/contexts/ui/ModalProvider.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import uniqid from 'uniqid';
 import { Grow, LinearProgress, Modal, Paper } from '@material-ui/core';
 
-import { ModalCtx, ModalOptions } from '../../types';
+import { ModalCtx, ModalOptions } from '@app/types';
 
 import useStyles from './ModalProvider.jss';
 

--- a/src/hooks/useFirebaseAuth.tsx
+++ b/src/hooks/useFirebaseAuth.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import { User, UserDocument } from '../types';
-import { UserAction } from '../reducers/User.Reducer';
-import { auth, usersCollection } from '../firebase/firebase';
+import { User, UserDocument } from '@app/types';
+
+import { UserAction } from '@app/reducers/User.Reducer';
+import { auth, usersCollection } from '@app/firebase/firebase';
 
 type useFirebaseAuthType = (
   user: User,

--- a/src/hooks/useUserCollection.tsx
+++ b/src/hooks/useUserCollection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { FetchedUser, QueriedUser, User } from '../types';
+import { FetchedUser, QueriedUser, User } from '@app/types';
 
 const useUserCollection = (
   user: User,

--- a/src/reducers/Events.Reducer.ts
+++ b/src/reducers/Events.Reducer.ts
@@ -1,4 +1,4 @@
-import { EventR51, Events } from '../types/';
+import { EventR51, Events } from '@app/types/';
 
 export type EventActionType = 'EMPTY' | 'ADDED' | 'MODIFIED' | 'REMOVED';
 export type EventAction =

--- a/src/reducers/User.Reducer.ts
+++ b/src/reducers/User.Reducer.ts
@@ -1,9 +1,10 @@
-import { User, UserDocument } from '../types';
+import { User, UserDocument } from '@app/types';
+
 import {
   initializeLoggedInUserState,
   loggedOutUser,
   shouldUpdateUserState,
-} from '../contexts/UserProps';
+} from '@app/contexts/UserProps';
 
 export type UserActionType = 'LOGGED_IN' | 'USER_FOUND' | 'LOGGED_OUT';
 export type UserAction =

--- a/src/types/components/navigation/index.ts
+++ b/src/types/components/navigation/index.ts
@@ -24,3 +24,16 @@ export interface NavItemParents {
     parents: string[];
   };
 }
+
+export interface SlideMenuState {
+  expandedNavItems: string[];
+  activeNavItem?: {
+    id: string;
+    path: string;
+    parents: string[];
+  };
+  expandNavItem: (id: string) => void;
+  collapseNavItem: (id: string) => void;
+}
+
+export type SlideMenuCtx = SlideMenuState | null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { EventFormPublicType, Hall, User, VerifiedUser } from '../types';
+import { EventFormPublicType, Hall, User, VerifiedUser } from '@app/types';
 
 export const canUpdateEvent = (
   publicStatus: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
     "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,8 +17,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
-    "baseUrl": "src"
+    "jsx": "react"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@app/*": ["src/*", "src/"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,6 +161,13 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-module-imports@^7.0.0":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz#dd331bd45bccc566ce77004e9d05fe17add13876"
+  integrity sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==
+  dependencies:
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
@@ -235,6 +242,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
+  integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
 
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
@@ -1003,6 +1015,15 @@
   integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.5"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.1.tgz#6886724d31c8022160a7db895e6731ca33483921"
+  integrity sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.1"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -2603,6 +2624,14 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-import@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import/-/babel-plugin-import-1.13.0.tgz#c532fd533df9db53b47d4d4db3676090fc5c07a5"
+  integrity sha512-bHU8m0SrY89ub2hBBuYjbennOeH0YUYkVpH6jxKFk0uD8rhN+0jNHIPtXnac+Vn7N/hgkLGGDcIoYK7je3Hhew==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
@@ -3899,6 +3928,13 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+customize-cra@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/customize-cra/-/customize-cra-1.0.0.tgz#73286563631aa08127ad4d30a2e3c89cf4e93c8d"
+  integrity sha512-DbtaLuy59224U+xCiukkxSq8clq++MOtJ1Et7LED1fLszWe88EoblEYFBJ895sB1mC6B4uu3xPT/IjClELhMbA==
+  dependencies:
+    lodash.flow "^3.5.0"
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -4464,6 +4500,14 @@ eslint-config-react-app@^5.1.0, eslint-config-react-app@^5.2.1:
   integrity sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
   dependencies:
     confusing-browser-globals "^1.0.9"
+
+eslint-import-resolver-custom-alias@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-custom-alias/-/eslint-import-resolver-custom-alias-1.2.0.tgz#b1e596c3c5c818ae4fc75478ec25dbef5d70e96d"
+  integrity sha512-UF5+nNKZOKqQStYHKJYii2cK3HegH6ZgBZdSGXFX3+S0iqoLl/0Ln7eHZZR3kSI3Qb3CAzQyE+Zsjmhp91jipw==
+  dependencies:
+    glob-parent "^5.1.0"
+    resolve "^1.3.0"
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
@@ -5449,7 +5493,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -7365,6 +7409,11 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.flow@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
+  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -9714,6 +9763,18 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-app-rewire-alias@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/react-app-rewire-alias/-/react-app-rewire-alias-0.1.4.tgz#320aa032810c3c25bc549fbb0e22e531d751e04e"
+  integrity sha512-M2+j/Re/qBrAyaJVK04JGZyNd4fYF1xrpWWM03lgCNNNRkPa7E2OVL0WUDHK2xyyOwBBwFYaPumoSTdzoo+PgA==
+
+react-app-rewired@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.6.tgz#33ee3076a7f34d6a7c94e649cac67e7c8c580de8"
+  integrity sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==
+  dependencies:
+    semver "^5.6.0"
+
 react-dev-utils@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.2.1.tgz#f6de325ae25fa4d546d09df4bb1befdc6dd19c19"
@@ -10233,7 +10294,7 @@ resolve@1.15.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,14 +4465,6 @@ eslint-config-react-app@^5.1.0, eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-import-resolver-custom-alias@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-custom-alias/-/eslint-import-resolver-custom-alias-1.2.0.tgz#b1e596c3c5c818ae4fc75478ec25dbef5d70e96d"
-  integrity sha512-UF5+nNKZOKqQStYHKJYii2cK3HegH6ZgBZdSGXFX3+S0iqoLl/0Ln7eHZZR3kSI3Qb3CAzQyE+Zsjmhp91jipw==
-  dependencies:
-    glob-parent "^5.1.0"
-    resolve "^1.3.0"
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -5457,7 +5449,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -10241,7 +10233,7 @@ resolve@1.15.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,6 +1931,16 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
+"@typescript-eslint/eslint-plugin@^2.3.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
+  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
@@ -1947,6 +1957,16 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "2.29.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
+  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -1989,6 +2009,19 @@
     is-glob "^4.0.1"
     lodash "^4.17.15"
     semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
+  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
     tsutils "^3.17.1"
 
 "@webassemblyjs/ast@1.8.5":
@@ -4631,6 +4664,22 @@ eslint-plugin-sort-imports-es6-autofix@^0.5.0:
   dependencies:
     eslint "^6.2.2"
 
+eslint-plugin-unused-imports@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-0.1.3.tgz#e7ba892576218218f793653d5337081c7ee0f991"
+  integrity sha512-hNbmvUhfy+Nf+9t2Sx720FsFRMkpWLaN5QSw0yUyplcOugvnRaLg9ylAK6DFu/S3J+IiPiHueZHKJh7lhggAXA==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^2.3.0"
+    eslint "^6.3.0"
+    eslint-rule-composer "^0.3.0"
+    requireindex "~1.1.0"
+    typescript "^3.6.3"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^3.7.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
@@ -4716,7 +4765,7 @@ eslint@^5.0.0:
     table "^5.2.3"
     text-table "^0.2.0"
 
-eslint@^6.2.2, eslint@^6.6.0, eslint@^6.8.0:
+eslint@^6.2.2, eslint@^6.3.0, eslint@^6.6.0, eslint@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
@@ -10234,6 +10283,11 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -10545,6 +10599,11 @@ semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -11566,6 +11625,11 @@ typescript@^3.2.1, typescript@^3.7.2:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.6.3:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Description of Changes
<!-- Summarize your code change. -->
- Changed the slide menu to a temporary mini variant drawer
- Added tooling support for mui tree shaking and ts path aliasing

# Motivation & Context
<!-- Why this code change was made. -->
- Design update
- Better production builds and DX

# Type of change
<!-- Mark all that apply (the fewer the better) -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature/Enhancement
- [ ] 🛠 Technical currency
- [x] 💎 Tooling change

# Snapshots
<!-- If not applicable, remove this section. -->
![2020-05-29_21-42-58](https://user-images.githubusercontent.com/22772637/83317851-95c50d00-a1f5-11ea-9f0e-6fa2b03ddd17.gif)

# Discussion:
<!-- Any other context or topics to be brought to attention. -->
There's a specific case (for larger screen sizes) for the slide menu that we need to make a decision on:
When the drawer is closed and the user clicks on an icon, right now that just opens the drawer. This was done because if the icon is on an expanding row you have to open the drawer to show the user the nested list. However when a user clicks on an icon on a "leaf" row that just leads to a route, the drawer will still open up and they'll just click the same row again. We could just select the "leaf" row instead of opening the drawer but then that creates the problem of users not being able to anticipate the result of their action without knowing the application's functionality. If a user clicks on the mini drawer once and it opens up the drawer and then he clicks on it a second time but this time the drawer doesn't open and he's just routed to a new screen, that's gonna make for confusing UX. The way I see it, we have three options:
a) Keep what we have right now (drawer opens up on every click)
b) Force all top level nav items to have a sub list
c) Scrap the mini variant drawer (which would hurt me a little inside but I'd be fine)  
